### PR TITLE
穴抜き箇所の反映部分に関する修正 + コーディングスタイルの修正

### DIFF
--- a/app/controllers/api/submissions_controller.rb
+++ b/app/controllers/api/submissions_controller.rb
@@ -77,7 +77,7 @@ class Api::SubmissionsController < ApplicationController
   end
 
   def new_submit_codes
-    pierced_locations = PiercedLocation.where(mission_id: @mission)
+    pierced_locations = PiercedLocation.where(mission_id: @mission, file_name: params[:file_name])
     code = code_param.map do |key, value|
       pierced_location = pierced_locations.find { |pl| pl.location_id == key.to_i }
       @submit.submit_codes.build(submit_codes_params(value, pierced_location))

--- a/app/models/pierced_location.rb
+++ b/app/models/pierced_location.rb
@@ -50,6 +50,7 @@ class PiercedLocation < ApplicationRecord
         'submit_codes.submit_id,
         submit_codes.file_name,
         submit_codes.code,
+        pierced_locations.id,
         pierced_locations.lines,
         pierced_locations.location_id'
       )

--- a/app/views/layouts/_preloader.slim
+++ b/app/views/layouts/_preloader.slim
@@ -53,7 +53,7 @@ javascript:
         $icon.className = 'fa fa-check fa-5x icon'
         $mes.innerText = message
 
-        $reducer = (accumulator, currentValue) => accumulator + '\n' + currentValue
+        reducer = (accumulator, currentValue) => accumulator + '\n' + currentValue
 
         $pre = document.createElement('pre')
         $pre.innerText = result.reduce($reducer)


### PR DESCRIPTION
解答が提出されていれば、最後の提出を反映させるが、採点用に他の穴抜き箇所が埋まった状態のコードを使っていたので、同じ大問内の他の問題の模範コードが表示されてしまっていた
コード提示用に穴抜き箇所を作成し、その穴抜き箇所に該当する提出されたコードがあれば、その最新のものを差し込む関数を新規に作成

採点時に、提出コードのファイル名を確認しておらず、別ファイルの同じlocation id(メタタグの後ろの数字)のところにマージされてしまうことがあったので修正

coffee scriptの命名規則で `$` を付けるのはelement型だけとのことなので、普通の関数であるreducerにつけてしまっていた `$` を削除